### PR TITLE
Export improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+report.**.json

--- a/src/ConfigureContentMap.tsx
+++ b/src/ConfigureContentMap.tsx
@@ -5,6 +5,7 @@ import {
 import { useNamespaces } from "./hooks/useNamespaces"
 import { BlockDataConfig } from "./BlockDataConfig"
 import { Sidebar } from "./Sidebar"
+import { ExportConfirmationModal } from "./ExportConfirmationModal"
 
 export const ConfigContentMap = (props: {
     namespace?: string
@@ -12,6 +13,7 @@ export const ConfigContentMap = (props: {
 }) => {
     const namespaces = useNamespaces()
     const [selectedNamespace, setSelectedNamespace] = useState(null as unknown as string)
+    const [showExportModal, setShowExportModal] = useState(false)
     const [sideBarIsOpen, setSidebarIsOpen] = useState(false)
 
     const handleClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
@@ -20,13 +22,13 @@ export const ConfigContentMap = (props: {
     }
 
     const toggleSidebar = () => {
-        console.log(`TOGGLE TO: `, !sideBarIsOpen)
         setSidebarIsOpen(!sideBarIsOpen)
     }
 
     return(
         <div className="flex overflow-x-hidden h-screen">
-            <Sidebar isOpen={sideBarIsOpen} toggleSidebarHandler={toggleSidebar}/>
+            <Sidebar isOpen={sideBarIsOpen} toggleSidebarHandler={toggleSidebar} openExportModalHandler={() => setShowExportModal(true)}/>
+            {!!showExportModal ? <ExportConfirmationModal cancelHandler={() => setShowExportModal(false)}/> : null}
             <div className="container flex-1 mx-auto">
                 <header>
                     <svg className="toggle-button h-6 w-6" onClick={toggleSidebar} xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/src/ExportConfirmationModal.tsx
+++ b/src/ExportConfirmationModal.tsx
@@ -1,0 +1,137 @@
+import React, { useEffect, useState } from "react"
+import { useContentMap } from "./hooks/useContentMap"
+
+export const ExportConfirmationModal = (props: {
+    cancelHandler: () => void
+}) => {
+    const [blockScaleSizes, setBlockScaleSizes] = useState([1])
+    const [scaleInput, setScaleInput] = useState(``)
+
+    // TODO: Use this for a content map review portion of the modal
+    // const contentMap = useContentMap({
+    //     watch: null
+    // })
+
+    const splitTextByCommas = (text: string) => {
+        return text.split(`,`)
+    }
+
+    /**
+     * Scale size input handler
+     * 
+     * This method is responsible for replacing spaces with commas, as well as preventing
+     * multiple commas from being used in succession. The end result should be a comma-separated
+     * list of numeric values.
+     * 
+     * @param e 
+     */
+    const scaleSizeInputHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
+        console.log(e.target.value)
+        const parsedText = e.target.value.replace(` `, `,`)
+        const lastChar = parsedText.slice(-1)
+        if (lastChar.match(/[a-z]/i)) return    // Exit early if a letter character was provided
+        const storedLastChar = scaleInput.slice(-1)
+        const values = splitTextByCommas(parsedText)
+        const isValidInput = (values.filter(val => {
+            console.log(parseInt(val))
+            let isValid = !isNaN(parseInt(val))
+            if (val === ``) {
+                isValid = true
+            }
+            return isValid
+        }).length === values.length)
+        if (isValidInput) {
+            if ((lastChar === `,` && storedLastChar !== `,`) || lastChar !== `,`) {
+                setScaleInput(parsedText)
+            }
+        } else if (parsedText === ``) {
+            setScaleInput(``)
+        }
+    }
+
+    const addBlockScaleSizes = (e: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
+        const sizes = scaleInput.split(`,`).map(str => parseInt(str))
+        // Used to prevent duplicates and automatically-sorts the list in ascending order (by value)
+        const obj = {} as any
+        blockScaleSizes.forEach(size => {
+            obj[size] = null
+        })
+        sizes.forEach(size => {
+            obj[size] = null
+        })
+        setBlockScaleSizes(Object.keys(obj).map(key => parseInt(key)))
+        setScaleInput(``)
+    }
+
+    const removeScaleSizeHandler = (size: number) => {
+        let newArr = blockScaleSizes
+        newArr.splice(blockScaleSizes.indexOf(size), 1)
+        setBlockScaleSizes([
+            ...newArr
+        ])
+    }
+
+    return (
+        <>
+            <div className="modal-overlay"/>
+            <div className="export-modal">
+                <h1>Confirm Export</h1>
+                <p>
+                    Review your content map and specify the export path before exporting
+                </p>
+                <form>
+                    <label>
+                        Export path:
+                        <input 
+                            className="export-modal-input" 
+                            type="input" 
+                            placeholder="..."
+                        />
+                    </label>
+                    <h3 className="export-modal-section-header">Block export settings</h3>
+                    <div>
+                        <label>
+                            Add block scale:
+                            <input 
+                                className="export-modal-input" 
+                                type="input" 
+                                onChange={scaleSizeInputHandler}
+                                placeholder="'1' or '1,2,3' etc" 
+                                value={scaleInput}
+                            />
+                        </label>
+                        <svg xmlns="http://www.w3.org/2000/svg" className="add-scale-size-button" fill="none" viewBox="0 0 24 24" stroke="currentColor" onClick={addBlockScaleSizes}>
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v3m0 0v3m0-3h3m-3 0H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                        <h4 className="export-modal-section-table-header">Block image sizes</h4>
+                        <p className="export-modal-section-table-description">
+                            The list of scale sizes that will be used when generating block images
+                        </p>
+                        <table className="export-modal-section-table">
+                            {blockScaleSizes.map((size, index) => {
+                                const isEven = index % 2 === 0
+                                return (
+                                    <tr className={!!isEven ? `bg-gray-200` : ``}>
+                                        <td className="space-x-4 px-4">
+                                            <label className="scale-table-label">scale</label>
+                                            <svg xmlns="http://www.w3.org/2000/svg" className="remove-scale-size-button" fill="none" viewBox="0 0 24 24" stroke="currentColor" onClick={() => removeScaleSizeHandler(size)}>
+                                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                                            </svg>
+                                            <p className="scale-table-value">{size}x</p>
+                                        </td>
+                                    </tr>
+                                )
+                            })}
+                        </table>
+                    </div>
+                    <div className="space-x-4">
+                        <button className="export-modal-cancel-button" onClick={props.cancelHandler}>Cancel</button>
+                        {/* TODO: Disable this button if any content type is missing scale sizes */}
+                        <input className="export-modal-save-button" type="submit" value="Submit"/>
+                    </div>
+                    
+                </form>
+            </div>
+        </>
+    )
+}

--- a/src/Sidebar.tsx
+++ b/src/Sidebar.tsx
@@ -5,6 +5,7 @@ import { useContentMap } from "./hooks/useContentMap"
 export const Sidebar = (props: {
     isOpen: boolean
     toggleSidebarHandler: () => void
+    openExportModalHandler: () => void
 }) => {
     // TODO: Fix this so that the user doesn't have to close and reopen the menu to see an up-to-date reflection of the stored data
     const cachedContentMap = useContentMap({
@@ -46,7 +47,7 @@ export const Sidebar = (props: {
                             </ul>
                         )
                     })}
-                    <button className="bottom-0" onClick={exportHandler}>Export</button>
+                    <button className="open-export-modal-button" onClick={() => props.openExportModalHandler()}>Export</button>
                 </>
             }
             </>

--- a/src/index.css
+++ b/src/index.css
@@ -70,7 +70,7 @@
   }
 
   .modal-overlay {
-    @apply absolute;
+    @apply fixed;
     @apply top-0;
     @apply left-0;
     @apply w-full;
@@ -142,6 +142,68 @@
   }
   .modal-dropdown-row > select {
     @apply w-24;
+  }
+
+  .export-modal {
+    @apply p-4;
+    @apply absolute;
+    @apply z-10;
+    @apply bg-white;
+    @apply w-1/2;
+    @apply transform translate-y-40 translate-x-1/2;
+    @apply rounded;
+  }
+  .export-modal h1, h2, h3, label, p, form {
+    @apply text-center;
+  }
+  .export-modal-section-table {
+    @apply w-1/3;
+    @apply mx-auto;
+    @apply space-x-4;
+  }
+  .scale-table-label {
+    @apply inline-block float-left;
+  }
+  .scale-table-value {
+    @apply inline-block float-right;
+  }
+  .add-scale-size-button {
+    @apply h-6 w-6;
+    @apply hover:text-blue-700;
+    @apply inline-block;
+  }
+  .remove-scale-size-button {
+    @apply h-6 w-6;
+    @apply inline-block float-right;
+    @apply hover:text-red-600;
+  }
+
+  .export-modal-input {
+    @apply px-2;
+    @apply m-2;
+    @apply rounded;
+    @apply bg-gray-200;
+  }
+  .export-modal-cancel-button {
+    @apply inline-block float-left;
+    @apply rounded;
+    @apply bg-gray-300 hover:bg-gray-400;
+    @apply px-2;
+  }
+  .export-modal-save-button {
+    @apply inline-block float-right;
+    @apply bg-blue-600 hover:bg-blue-700;
+    @apply text-white;
+    @apply rounded;
+    @apply px-2;
+  }
+
+  .open-export-modal-button {
+    @apply absolute bottom-0 m-4 p-4;
+    @apply transform translate-x-20;
+    @apply bg-green-500 hover:bg-green-600 rounded;
+    @apply focus:outline-none;
+    @apply text-white;
   }
 
   .block-grid {


### PR DESCRIPTION
# Description

> This technically "breaks" exporting in that you'll no longer get a generated content map after clicking the "Export" button in the side menu; now there is a modal that pops up, where the user should configure their content map before exporting it to a specified location. **In order for this integration to be completed, new server endpoints will be needed in the CLI tool**

Adds a very rudimentary export modal, and some style improvements (though the CSS file is a bit chaotic right now - that will be addressed later)

Sidebar update:
![sidebar](https://user-images.githubusercontent.com/14364659/115822255-d7404700-a3c9-11eb-949a-d44d3f339754.png)

Export modal:
![export_modal](https://user-images.githubusercontent.com/14364659/115822291-e58e6300-a3c9-11eb-9e41-0d77fef69ff5.png)

