### PR TITLE
Sanity export support

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,4 @@
+export enum EXPORT_LOCATION {
+    FILE_SYSTEM = `fs`,
+    SANITY = `sanity`
+}


### PR DESCRIPTION
# Description

This PR adds a toggle to the export modal that allows the user to select either "fs" or "sanity" as the export location. When Sanity is selected, the user will need to provide a project name and auth token (which they can get from the Sanity CLI).