### PR TITLE
Block sorting (asc/desc)

### DIFF
--- a/src/BlockDataConfig.tsx
+++ b/src/BlockDataConfig.tsx
@@ -24,6 +24,7 @@ export const BlockDataConfig = (props: {
     namespace: string
 }) => {
     const [page, setPage] = useState(1)
+    const [sortOrder, setSortOrder] = useState(`ascending`)
     const [modalState, dispatch] = useReducer(reducer, {
         showModal: false,
         modalData: null
@@ -34,7 +35,8 @@ export const BlockDataConfig = (props: {
     })
     const blockRecords = usePaginatedBlocksForNamespace({
         page,
-        namespace: props.namespace
+        namespace: props.namespace,
+        sortOrder: sortOrder as `ascending` | `descending`,
     })
 
     const nextPageHandler = () => {
@@ -51,6 +53,10 @@ export const BlockDataConfig = (props: {
 
     const dismissModal = () => {
         dispatch({ type: 'close_modal' })
+    }
+
+    const sortOrderHandler = (order: `ascending` | `descending`) => {
+        setSortOrder(order)
     }
 
     return (
@@ -72,6 +78,17 @@ export const BlockDataConfig = (props: {
                         texture for one, two, or all sides (e.g., to add a block defition that uses the same texture for all sides, simply set it
                         as the texture to use for all sides).
                     </p>
+                </div>
+                <div className="pagination-config">
+                        <label className="flex flex-col">
+                            <input className="mx-auto" type="radio" checked={sortOrder === `ascending`} onClick={e => sortOrderHandler(`ascending`)}/>
+                            ASC
+                        </label>
+                        <label className="ml-4 flex flex-col">
+                            <input className="mx-auto" type="radio" checked={sortOrder === `descending`} onClick={e => sortOrderHandler(`descending`)}/>
+                            DESC
+                        </label>
+                    
                 </div>
                 <div className="block-grid">
                     {blockRecords.map(record => {

--- a/src/hooks/usePaginatedBlocksForNamespace.ts
+++ b/src/hooks/usePaginatedBlocksForNamespace.ts
@@ -5,6 +5,7 @@ import { BlockModelData } from "../minecraft/types"
 export const usePaginatedBlocksForNamespace = (props: {
     page: number
     namespace: string
+    sortOrder: `ascending` | `descending`
 }) => {
     const [blockRecords, setBlockRecords] = useState([] as {
         block: string
@@ -12,12 +13,12 @@ export const usePaginatedBlocksForNamespace = (props: {
     }[])
 
     useEffect(() => {
-        axios.get(`http://localhost:3000/raw-data/blocks?page=${props.page}&namespace=${props.namespace}&limit=12`)
+        axios.get(`http://localhost:3000/raw-data/blocks?page=${props.page}&namespace=${props.namespace}&limit=12&order=${props.sortOrder}`)
             .then(res => {
                 const blocks = res.data.items
                 setBlockRecords(blocks)
             })
-    }, [props.namespace, props.page])
+    }, [props.namespace, props.page, props.sortOrder])
 
     return blockRecords
 }

--- a/src/index.css
+++ b/src/index.css
@@ -20,6 +20,11 @@
     @apply text-4xl;
   }
 
+  .pagination-config {
+    @apply flex flex-row;
+    @apply justify-center;
+  }
+
   .sidebar {
     @apply fixed;
     @apply flex;


### PR DESCRIPTION
# Description

Adds rudimentary UI to toggle the block pagination between ascending (default) and descending order.